### PR TITLE
Support nested graph visualization

### DIFF
--- a/src/lib/codeToMermaid.test.ts
+++ b/src/lib/codeToMermaid.test.ts
@@ -16,8 +16,11 @@ nodes:
 `,
       expected: `
 flowchart TD
+ input(input)
  output(output<br/><span class="agent-name">echoAgent</span>)
  input(input) --> output
+class input staticNode
+class output computedNode
 `.trim()
     },
     {
@@ -57,7 +60,9 @@ nodes:
 `,
       expected: `
 flowchart TD
+ fruits(fruits)
  shift(shift<br/><span class="agent-name">shiftAgent</span>) -- array --> fruits
+ result(result)
  reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> result
  shift(shift<br/><span class="agent-name">shiftAgent</span>)
  fruits(fruits) --> shift
@@ -68,6 +73,8 @@ flowchart TD
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
  result(result) --> reducer
  llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message.content --> reducer
+class fruits,result staticNode
+class shift,prompt,llm,reducer computedNode
 `.trim()
     },
     {
@@ -131,7 +138,9 @@ nodes:
 `,
       expected: `
 flowchart TD
+ continue(continue)
  checkInput(checkInput<br/><span class="agent-name">propertyFilterAgent</span>) -- continue --> continue
+ messages(messages)
  reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> messages
  userInput(userInput<br/><span class="agent-name">textInputAgent</span>)
  checkInput(checkInput<br/><span class="agent-name">propertyFilterAgent</span>)
@@ -148,6 +157,8 @@ flowchart TD
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
  appendedMessages(appendedMessages<br/><span class="agent-name">pushAgent</span>) --> reducer
  llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message --> reducer
+class continue,messages staticNode
+class userInput,checkInput,userMessage,appendedMessages,llm,output,reducer computedNode
 `.trim()
     }
   ];
@@ -179,8 +190,11 @@ describe('codeToMermaid -- json', () => {
 }`,
       expected: `
 flowchart TD
+ input(input)
  output(output<br/><span class="agent-name">echoAgent</span>)
  input(input) --> output
+class input staticNode
+class output computedNode
 `.trim()
     },
     {
@@ -233,7 +247,9 @@ flowchart TD
 }`,
       expected: `
 flowchart TD
+ fruits(fruits)
  shift(shift<br/><span class="agent-name">shiftAgent</span>) -- array --> fruits
+ result(result)
  reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> result
  shift(shift<br/><span class="agent-name">shiftAgent</span>)
  fruits(fruits) --> shift
@@ -244,6 +260,8 @@ flowchart TD
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
  result(result) --> reducer
  llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message.content --> reducer
+class fruits,result staticNode
+class shift,prompt,llm,reducer computedNode
 `.trim()
     }
   ];

--- a/src/lib/codeToMermaid.test.ts
+++ b/src/lib/codeToMermaid.test.ts
@@ -273,3 +273,187 @@ class shift,prompt,llm,reducer computedNode
     });
   });
 });
+
+describe(`codeToMermaid -- yaml, nested nodes`, () => {
+  const testCases = [
+    {
+      name: 'should convert simple nested nodes with iterative inputs',
+      yaml: `
+version: 0.5
+nodes:
+  fruits:
+    value: [apple, lemomn, banana]
+  map:
+    agent: mapAgent
+    inputs:
+      rows: :fruits
+    isResult: true
+    graph:
+      nodes:
+        llm:
+          agent: openAIAgent
+          params:
+            model: gpt-4o
+          inputs:
+            prompt: What is the typical color of \${:row}? Just answer the color.
+        result:
+          agent: copyAgent
+          params:
+            namedKey: item
+          inputs:
+            item: :llm.text
+          isResult: true
+`,
+      expected: `
+flowchart TD
+ fruits(fruits)
+ fruits --> map
+ subgraph map[map: <span class="agent-name">mapAgent</span>]
+  map.llm(llm<br/><span class="agent-name">openAIAgent</span>)
+  map.row --> map.llm
+  map.result(result<br/><span class="agent-name">copyAgent</span>)
+  map.llm -- text --> map.result
+ end
+class fruits staticNode
+class map.llm,map.result computedNode
+class map nestedGraph
+`.trim(),
+    },
+    {
+      name: 'should convert nested node with template input',
+      yaml: `
+version: 0.5
+nodes:
+  source1:
+    value:
+      fruit: apple
+  source2:
+    value:
+      fruit: orange
+  source3:
+    value:
+      fruit: banana
+  source4:
+    value:
+      fruit: lemon
+  nestedNode:
+    agent: mapAgent
+    inputs:
+      rows:
+        - :source1.fruit
+        - :source2.fruit
+        - :source3.fruit
+        - :source4.fruit
+    graph:
+      version: 0.5
+      nodes:
+        node2:
+          agent: stringTemplateAgent
+          params:
+            template: "I love \${row}."
+          inputs: row :row
+          isResult: true
+  result:
+    agent: sleeperAgent
+    inputs:
+      array: [:nestedNode]
+    isResult: true
+`,
+      expected: `
+flowchart TD
+ source1(source1)
+ source2(source2)
+ source3(source3)
+ source4(source4)
+ source1 -- fruit --> nestedNode
+ source2 -- fruit --> nestedNode
+ source3 -- fruit --> nestedNode
+ source4 -- fruit --> nestedNode
+ subgraph nestedNode[nestedNode: <span class="agent-name">mapAgent</span>]
+  nestedNode.node2(node2<br/><span class="agent-name">stringTemplateAgent</span>)
+ end
+ result(result<br/><span class="agent-name">sleeperAgent</span>)
+ nestedNode --> result
+class source1,source2,source3,source4 staticNode
+class nestedNode.node2,result computedNode
+class nestedNode nestedGraph
+`.trim(),
+    },
+    {
+      name: 'should convert dynamic nested node',
+      yaml: `
+version: 0.5
+nodes:
+  document:
+    agent: fetchAgent
+    console:
+      before: ...fetching document
+    params:
+      type: text
+    inputs:
+      url: https://raw.githubusercontent.com/receptron/graphai/main/packages/graphai/README.md
+  sampleGraph:
+    agent: fetchAgent
+    console:
+      before: ...fetching sample graph
+    params:
+      type: text
+    inputs:
+      url: https://raw.githubusercontent.com/receptron/graphai/refs/heads/main/packages/samples/graph_data/openai/reception.yaml
+  graphGenerator:
+    agent: openAIAgent
+    console:
+      before: ...generating a new graph
+    params:
+      model: gpt-4o
+    inputs:
+      prompt: Name, Address and Phone Number
+      messages:
+        - role: system
+          content: >-
+            You an expert in GraphAI programming. You are responsible in
+            generating a graphAI graph to get required information from the
+            user.
+
+            graphAI graph outputs in json format
+
+            [documation of GraphAI]
+
+            \${:document}
+        - role: user
+          content: Name, Date of Birth and Gendar
+        - role: assistant
+          content: |
+            \`\`\`json
+            \${:sampleGraph}
+            \`\`\`
+  executer:
+    agent: nestedAgent
+    graph: :graphGenerator.text.codeBlock().jsonParse()
+    isResult: true
+`,
+      expected: `
+flowchart TD
+ document(document<br/><span class="agent-name">fetchAgent</span>)
+ sampleGraph(sampleGraph<br/><span class="agent-name">fetchAgent</span>)
+ graphGenerator(graphGenerator<br/><span class="agent-name">openAIAgent</span>)
+ document --> graphGenerator
+ sampleGraph --> graphGenerator
+ graphGenerator -- text.codeBlock().jsonParse() --> executer
+ subgraph executer[executer: <span class="agent-name">nestedAgent</span>]
+ end
+class document,sampleGraph,graphGenerator computedNode
+class executer nestedGraph    
+`.trim()
+    }
+  ];
+
+  testCases.forEach(({ name, yaml, expected }) => {
+    it(name, () => {
+      const result = codeToMermaid(yaml, 'yaml'); 
+      expect(result).toBe(expected);
+    });
+  });
+});
+
+

--- a/src/lib/codeToMermaid.test.ts
+++ b/src/lib/codeToMermaid.test.ts
@@ -18,7 +18,7 @@ nodes:
 flowchart TD
  input(input)
  output(output<br/><span class="agent-name">echoAgent</span>)
- input(input) --> output
+ input --> output
 class input staticNode
 class output computedNode
 `.trim()
@@ -61,18 +61,18 @@ nodes:
       expected: `
 flowchart TD
  fruits(fruits)
- shift(shift<br/><span class="agent-name">shiftAgent</span>) -- array --> fruits
+ shift -- array --> fruits
  result(result)
- reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> result
+ reducer --> result
  shift(shift<br/><span class="agent-name">shiftAgent</span>)
- fruits(fruits) --> shift
+ fruits --> shift
  prompt(prompt<br/><span class="agent-name">stringTemplateAgent</span>)
- shift(shift<br/><span class="agent-name">shiftAgent</span>) -- item --> prompt
+ shift -- item --> prompt
  llm(llm<br/><span class="agent-name">openAIAgent</span>)
- prompt(prompt<br/><span class="agent-name">stringTemplateAgent</span>) --> llm
+ prompt --> llm
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
- result(result) --> reducer
- llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message.content --> reducer
+ result --> reducer
+ llm -- choices.$0.message.content --> reducer
 class fruits,result staticNode
 class shift,prompt,llm,reducer computedNode
 `.trim()
@@ -139,24 +139,24 @@ nodes:
       expected: `
 flowchart TD
  continue(continue)
- checkInput(checkInput<br/><span class="agent-name">propertyFilterAgent</span>) -- continue --> continue
+ checkInput -- continue --> continue
  messages(messages)
- reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> messages
+ reducer --> messages
  userInput(userInput<br/><span class="agent-name">textInputAgent</span>)
  checkInput(checkInput<br/><span class="agent-name">propertyFilterAgent</span>)
- userInput(userInput<br/><span class="agent-name">textInputAgent</span>) --> checkInput
+ userInput --> checkInput
  userMessage(userMessage<br/><span class="agent-name">propertyFilterAgent</span>)
- userInput(userInput<br/><span class="agent-name">textInputAgent</span>) --> userMessage
+ userInput --> userMessage
  appendedMessages(appendedMessages<br/><span class="agent-name">pushAgent</span>)
- messages(messages) --> appendedMessages
- userMessage(userMessage<br/><span class="agent-name">propertyFilterAgent</span>) --> appendedMessages
+ messages --> appendedMessages
+ userMessage --> appendedMessages
  llm(llm<br/><span class="agent-name">openAIAgent</span>)
- appendedMessages(appendedMessages<br/><span class="agent-name">pushAgent</span>) --> llm
+ appendedMessages --> llm
  output(output<br/><span class="agent-name">stringTemplateAgent</span>)
- llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message.content --> output
+ llm -- choices.$0.message.content --> output
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
- appendedMessages(appendedMessages<br/><span class="agent-name">pushAgent</span>) --> reducer
- llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message --> reducer
+ appendedMessages --> reducer
+ llm -- choices.$0.message --> reducer
 class continue,messages staticNode
 class userInput,checkInput,userMessage,appendedMessages,llm,output,reducer computedNode
 `.trim()
@@ -192,7 +192,7 @@ describe('codeToMermaid -- json', () => {
 flowchart TD
  input(input)
  output(output<br/><span class="agent-name">echoAgent</span>)
- input(input) --> output
+ input --> output
 class input staticNode
 class output computedNode
 `.trim()
@@ -248,18 +248,18 @@ class output computedNode
       expected: `
 flowchart TD
  fruits(fruits)
- shift(shift<br/><span class="agent-name">shiftAgent</span>) -- array --> fruits
+ shift -- array --> fruits
  result(result)
- reducer(reducer<br/><span class="agent-name">pushAgent</span>) --> result
+ reducer --> result
  shift(shift<br/><span class="agent-name">shiftAgent</span>)
- fruits(fruits) --> shift
+ fruits --> shift
  prompt(prompt<br/><span class="agent-name">stringTemplateAgent</span>)
- shift(shift<br/><span class="agent-name">shiftAgent</span>) -- item --> prompt
+ shift -- item --> prompt
  llm(llm<br/><span class="agent-name">openAIAgent</span>)
- prompt(prompt<br/><span class="agent-name">stringTemplateAgent</span>) --> llm
+ prompt --> llm
  reducer(reducer<br/><span class="agent-name">pushAgent</span>)
- result(result) --> reducer
- llm(llm<br/><span class="agent-name">openAIAgent</span>) -- choices.$0.message.content --> reducer
+ result --> reducer
+ llm -- choices.$0.message.content --> reducer
 class fruits,result staticNode
 class shift,prompt,llm,reducer computedNode
 `.trim()

--- a/src/lib/codeToMermaid.ts
+++ b/src/lib/codeToMermaid.ts
@@ -25,16 +25,18 @@ const addConnectionsToGraph = ({
   }
 };
 
-export const codeToMermaid = (code: string, fileLanguageId: string) => {
-  if (fileLanguageId !== 'yaml' && fileLanguageId !== 'json') {
-    return ''
+const processGraph = (
+  { graphData, 
+    lines, 
+    staticNodes, 
+    dynamicNodes,
+  }: { 
+    graphData: GraphData, 
+    lines: string[], 
+    staticNodes: string[], 
+    dynamicNodes: string[] 
   }
-  const graphData = fileLanguageId === 'yaml' ? YAML.parse(code) as GraphData : JSON.parse(code) as GraphData;
-  const lines: string[] = ["flowchart TD"];
-
-  const staticNodes: string[] = [];
-  const dynamicNodes: string[] = [];
-
+  ) => {
   Object.keys(graphData.nodes).forEach((nodeId) => {
     const node = graphData.nodes[nodeId];
     if ("agent" in node) {
@@ -46,12 +48,25 @@ export const codeToMermaid = (code: string, fileLanguageId: string) => {
     } else {
       lines.push(` ${nodeId}(${nodeId})`);
       staticNodes.push(nodeId);
-
+  
       if ("update" in node) {
         addConnectionsToGraph({ lines, nodeId, inputs: { update: node.update }, graphData });
       }
     }
   });
+};
+
+export const codeToMermaid = (code: string, fileLanguageId: string) => {
+  if (fileLanguageId !== 'yaml' && fileLanguageId !== 'json') {
+    return ''
+  }
+  const graphData = fileLanguageId === 'yaml' ? YAML.parse(code) as GraphData : JSON.parse(code) as GraphData;
+  const lines: string[] = ["flowchart TD"];
+
+  const staticNodes: string[] = [];
+  const dynamicNodes: string[] = [];
+
+  processGraph({ graphData, lines, staticNodes, dynamicNodes });
 
   if (staticNodes.length > 0) {
     lines.push(`class ${staticNodes.join(',')} staticNode`);

--- a/src/lib/codeToMermaid.ts
+++ b/src/lib/codeToMermaid.ts
@@ -15,13 +15,10 @@ const addConnectionsToGraph = ({
   if (graphData) {
     inputs2dataSources(inputs).map((source) => {
       if (source.nodeId) {
-        const sourceNode = graphData.nodes[source.nodeId];
-        const sourceAgentName = sourceNode && "agent" in sourceNode ? `<br/><span class="agent-name">${sourceNode.agent}</span>` : '';
-
         if (source.propIds) {
-          lines.push(` ${source.nodeId}(${source.nodeId}${sourceAgentName}) -- ${source.propIds.join(".")} --> ${nodeId}`);
+          lines.push(` ${source.nodeId} -- ${source.propIds.join(".")} --> ${nodeId}`);
         } else {
-          lines.push(` ${source.nodeId}(${source.nodeId}${sourceAgentName}) --> ${nodeId}`);
+          lines.push(` ${source.nodeId} --> ${nodeId}`);
         }
       }
     });

--- a/src/lib/codeToMermaid.ts
+++ b/src/lib/codeToMermaid.ts
@@ -1,56 +1,105 @@
 import YAML from "yaml";
 import { GraphData, inputs2dataSources } from "graphai";
 
+/**
+ * Creates an indentation string based on the depth of the node path.
+ * The indentation level is determined by counting the number of segments in the path.
+ * 
+ * @param parentNodePath - The dot-separated path to the parent node
+ * @returns A string with spaces for indentation
+ */
+const makeIndent = (parentNodePath: string) => " ".repeat(parentNodePath.split(".").length);
+
 const addConnectionsToGraph = ({
   lines,
   nodeId,
   inputs,
-  graphData
+  graphData,
+  parentNodePath,
 }: {
   lines: string[],
   nodeId: string,
   inputs: any,
-  graphData: GraphData
+  graphData: GraphData,
+  parentNodePath: string,
 }) => {
   if (graphData) {
-    inputs2dataSources(inputs).map((source) => {
+    const indent = makeIndent(parentNodePath);
+    let sources = inputs2dataSources(inputs);
+    if (!Array.isArray(sources)) {
+      sources = [sources];
+    }
+    sources.map((source) => {
       if (source.nodeId) {
         if (source.propIds) {
-          lines.push(` ${source.nodeId} -- ${source.propIds.join(".")} --> ${nodeId}`);
+          lines.push(`${indent}${parentNodePath}${source.nodeId} -- ${source.propIds.join(".")} --> ${parentNodePath}${nodeId}`);
         } else {
-          lines.push(` ${source.nodeId} --> ${nodeId}`);
+          lines.push(`${indent}${parentNodePath}${source.nodeId} --> ${parentNodePath}${nodeId}`);
         }
       }
     });
   }
 };
 
-const processGraph = (
-  { graphData, 
-    lines, 
-    staticNodes, 
-    dynamicNodes,
-  }: { 
-    graphData: GraphData, 
-    lines: string[], 
-    staticNodes: string[], 
-    dynamicNodes: string[] 
-  }
-  ) => {
+/**
+ * Processes a graph structure and converts it to Mermaid flowchart syntax.
+ * This function recursively traverses the graph data structure, generating Mermaid
+ * 
+ * @param graphData - The graph data structure to process
+ * @param lines - Array to collect the generated Mermaid syntax lines
+ * @param staticNodes - Array to collect static node IDs for styling
+ * @param computedNodes - Array to collect computed node IDs for styling
+ * @param nestedGraphNodes - Array to collect nested graph node IDs for styling
+ * @param parentNodePath - The path to the parent node, used for nesting and indentation
+ */
+const processGraph = ({
+  graphData,
+  lines,
+  staticNodes,
+  computedNodes,
+  nestedGraphNodes,
+  parentNodePath = "",
+}: {
+  graphData: GraphData,
+  lines: string[],
+  staticNodes: string[],
+  computedNodes: string[],
+  nestedGraphNodes: string[],
+  parentNodePath: string,
+}) => {
   Object.keys(graphData.nodes).forEach((nodeId) => {
     const node = graphData.nodes[nodeId];
-    if ("agent" in node) {
-      lines.push(` ${nodeId}(${nodeId}<br/><span class="agent-name">${node.agent}</span>)`);
-      if (node.inputs) {
-        addConnectionsToGraph({ lines, nodeId, inputs: node.inputs, graphData });
+    const fullNodeId = `${parentNodePath}${nodeId}`;
+    const indent = makeIndent(parentNodePath);
+    if ("graph" in node) {
+      const inputs = typeof node.graph === "string" ? node.graph : node.inputs;
+      if (inputs) {
+        addConnectionsToGraph({ lines, nodeId, inputs, graphData, parentNodePath });
       }
-      dynamicNodes.push(nodeId);
+      lines.push(`${indent}subgraph ${fullNodeId}[${nodeId}: <span class="agent-name">${node.agent}</span>]`);
+      if ((node.graph as GraphData).nodes) {
+        processGraph({
+          graphData: node.graph as GraphData,
+          lines,
+          staticNodes,
+          computedNodes,
+          nestedGraphNodes,
+          parentNodePath: `${fullNodeId}.`,
+        });
+      }
+      lines.push(`${indent}end`);
+      nestedGraphNodes.push(fullNodeId);
+    } else if ("agent" in node) {
+      lines.push(`${indent}${fullNodeId}(${nodeId}<br/><span class="agent-name">${node.agent}</span>)`);
+      if (node.inputs) {
+        addConnectionsToGraph({ lines, nodeId, inputs: node.inputs, graphData, parentNodePath });
+      }
+      computedNodes.push(fullNodeId);
     } else {
-      lines.push(` ${nodeId}(${nodeId})`);
-      staticNodes.push(nodeId);
-  
+      lines.push(`${indent}${fullNodeId}(${nodeId})`);
+      staticNodes.push(fullNodeId);
       if ("update" in node) {
-        addConnectionsToGraph({ lines, nodeId, inputs: { update: node.update }, graphData });
+        addConnectionsToGraph({ lines, nodeId, inputs: { update: node.update }, graphData, parentNodePath });
       }
     }
   });
@@ -64,16 +113,28 @@ export const codeToMermaid = (code: string, fileLanguageId: string) => {
   const lines: string[] = ["flowchart TD"];
 
   const staticNodes: string[] = [];
-  const dynamicNodes: string[] = [];
+  const computedNodes: string[] = [];
+  const nestedGraphNodes: string[] = [];
 
-  processGraph({ graphData, lines, staticNodes, dynamicNodes });
+  processGraph({
+    graphData,
+    lines,
+    staticNodes,
+    computedNodes,
+    nestedGraphNodes,
+    parentNodePath: "",
+  });
 
   if (staticNodes.length > 0) {
     lines.push(`class ${staticNodes.join(',')} staticNode`);
   }
 
-  if (dynamicNodes.length > 0) {
-    lines.push(`class ${dynamicNodes.join(',')} computedNode`);
+  if (computedNodes.length > 0) {
+    lines.push(`class ${computedNodes.join(',')} computedNode`);
+  }
+
+  if (nestedGraphNodes.length > 0) {
+    lines.push(`class ${nestedGraphNodes.join(',')} nestedGraph`);
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Overview
This PR adds support for nested graph visualization in the Mermaid flowchart generation.

## Changes

- Fixed test results to actual behavior
- Fixed node connection representation for better readability

### Added supports for nested graph structures
- Added proper indentation for nested nodes in the generated Mermaid syntax
- Added styling for nested graph nodes with a new 'nestedGraph' class
- Added comprehensive test cases for nested graph visualization

Example for simple nested node: 

[Source GraphAI YAML](https://github.com/receptron/graphai/blob/d7eae4e8d8c3f02a941e18f83462946d221ff1cc/packages/samples/src/simple/map.yaml)

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b497778c-f14c-4320-9b39-4e16e8af861f) | ![image](https://github.com/user-attachments/assets/2c7d6e82-cc15-4cd7-ada1-c3f7fcd7ac15) |

## Test Cases
Added test cases that verify:
- Simple nested nodes with iterative inputs
- Nested nodes with template inputs
- Dynamic nested nodes with complex structures
