### PR TITLE
TypeScript Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![Version](https://img.shields.io/visual-studio-marketplace/v/receptron.graphai-visualizer)](https://marketplace.visualstudio.com/items?itemName=receptron.graphai-visualizer) [![Installs](https://img.shields.io/visual-studio-marketplace/i/receptron.graphai-visualizer)](https://marketplace.visualstudio.com/items?itemName=receptron.graphai-visualizer) [![Reactive VSCode](https://img.shields.io/badge/Reactive-VSCode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.github.io/reactive-vscode/)
 
-GraphAI Visualizer is a VS Code extension for visualizing JSON and YAML graphs defined with [GraphAI](https://github.com/receptron/graphai). Built using [Reactive VS Code](https://kermanx.github.io/reactive-vscode/).
+GraphAI Visualizer is a VS Code extension for visualizing JSON and YAML graphs defined with [GraphAI](https://github.com/receptron/graphai), as well as GraphAI objects in TypeScript files. Built using [Reactive VS Code](https://kermanx.github.io/reactive-vscode/).
 
 <img src="https://github.com/user-attachments/assets/d83aae3f-786e-4f3d-bd29-f3687d23b7a8" width="700">
 
 ## Features
 
 - Automatically parses GraphAI JSON and YAML files
+- Extracts and visualizes GraphAI objects from TypeScript files
 - Visualizes graphs using Mermaid
 - Intuitive zoom, pan, and reset functionality
 - Auto-updates when files are saved
@@ -16,17 +17,26 @@ GraphAI Visualizer is a VS Code extension for visualizing JSON and YAML graphs d
 
 ## Usage
 
-1. Open a JSON or YAML file
-2. Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and search for "Show Graph: GraphAI Visualizer"
+### For JSON or YAML files
+1. Open a JSON or YAML file containing GraphAI graph definition
+2. Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and search for "GraphAI: Show Graph Visualization"
 3. The graph will appear in a separate window
 4. Drag within the graph to pan, use buttons to zoom in/out or reset
 5. Edit and save your file to automatically update the graph
+
+### For TypeScript files
+1. Open a TypeScript file containing GraphAI object definitions
+2. Place your cursor inside a GraphAI object
+3. Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and search for "GraphAI: Show Graph Visualization"
+4. The extension will extract the object at the cursor position and visualize it
 
 ## Directory Structure
 
 * `package.json` - the manifest file in which you declare your extension and command
 * `src/extension.ts` - the main file for the extension
 * `src/lib/codeToMermaid.ts` - logic to convert GraphAI JSON or YAML to Mermaid format
+* `src/lib/objectParser.ts` - extracts GraphAI objects from TypeScript files
+* `src/composables/useGraphAIParser.ts` - handles parsing GraphAI objects from cursor position
 
 ## Get started
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "graphai": "^0.6.26",
+    "typescript": "^5.4.5",
     "yaml": "^2.7.0"
   }
 }

--- a/src/composables/useGraphAIParser.ts
+++ b/src/composables/useGraphAIParser.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import { parseObjectWithReferences } from '../lib/objectParser';
+import { logger } from '../utils';
+
+/**
+ * Parses GraphAI object from cursor position
+ */
+export async function parseGraphAIObject(document: vscode.TextDocument, position: vscode.Position): Promise<string | null> {
+  try {
+    const sourceCode = document.getText();
+
+    // Parse object with all variable references resolved
+    const jsonSafeObject = parseObjectWithReferences(sourceCode, position);
+
+    if (!jsonSafeObject) {
+      vscode.window.showInformationMessage('No object found at cursor position.');
+      return null;
+    }
+
+    // Check if the object looks like a GraphAI graph
+    if (!isGraphAILike(jsonSafeObject)) {
+      vscode.window.showInformationMessage('The object at cursor position does not appear to be a GraphAI graph.');
+      return null;
+    }
+
+    // Convert to JSON string
+    return JSON.stringify(jsonSafeObject, null, 2);
+  } catch (error) {
+    vscode.window.showErrorMessage('Error parsing object.');
+    logger.error('Object parsing error:', error);
+    return null;
+  }
+}
+
+/**
+ * Checks if an object looks like a GraphAI graph
+ */
+function isGraphAILike(obj: any): boolean {
+  // Check for typical GraphAI properties
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  // Check for nodes, version, edges properties
+  const hasTypicalProps = obj.nodes || obj.version || obj.edges;
+
+  // Check nodes object contents
+  if (obj.nodes && typeof obj.nodes === 'object') {
+    // Look for agent or value properties in nodes
+    for (const nodeName in obj.nodes) {
+      const node = obj.nodes[nodeName];
+      if (node && typeof node === 'object' && (node.agent || node.value !== undefined)) {
+        return true;
+      }
+    }
+  }
+
+  return hasTypicalProps;
+}

--- a/src/lib/objectParser.ts
+++ b/src/lib/objectParser.ts
@@ -1,0 +1,236 @@
+import * as ts from 'typescript';
+import * as vscode from 'vscode';
+
+/**
+ * Searches for the object literal that includes the cursor position in the source file
+ */
+export function findObjectAtPosition(sourceCode: string, position: vscode.Position): ts.ObjectLiteralExpression | null {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceCode,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  let targetNode: ts.ObjectLiteralExpression | null = null;
+
+  // Convert cursor position to offset
+  const offset = ts.getPositionOfLineAndCharacter(sourceFile, position.line, position.character);
+
+  function findNode(node: ts.Node): void {
+    if (targetNode) return;
+
+    // Check if the cursor position is within the node's range
+    if (node.getStart() <= offset && offset <= node.getEnd()) {
+      if (ts.isObjectLiteralExpression(node)) {
+        targetNode = node;
+      }
+
+      // Recursively search child nodes
+      node.forEachChild(findNode);
+    }
+  }
+
+  sourceFile.forEachChild(findNode);
+  return targetNode;
+}
+
+/**
+ * Finds variable definition and retrieves its value
+ */
+function findVariableDefinition(sourceFile: ts.SourceFile, variableName: string): ts.Node | null {
+  let result: ts.Node | null = null;
+
+  function findVariable(node: ts.Node) {
+    if (result) return;
+
+    // Search for variable declarations
+    if (ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === variableName &&
+        node.initializer) {
+      result = node.initializer;
+      return;
+    }
+
+    // Search for other declarations (e.g., export const)
+    if (ts.isVariableStatement(node)) {
+      node.declarationList.declarations.forEach(declaration => {
+        if (ts.isIdentifier(declaration.name) &&
+            declaration.name.text === variableName &&
+            declaration.initializer) {
+          result = declaration.initializer;
+        }
+      });
+    }
+
+    // Search for properties in objects
+    if (ts.isObjectLiteralExpression(node)) {
+      node.properties.forEach(prop => {
+        if (ts.isPropertyAssignment(prop) &&
+            ts.isIdentifier(prop.name) &&
+            prop.name.text === variableName) {
+          result = prop.initializer;
+        }
+      });
+    }
+
+    // Search for module exports
+    if (ts.isExportAssignment(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === variableName) {
+      result = node.expression;
+    }
+
+    node.forEachChild(findVariable);
+  }
+
+  sourceFile.forEachChild(findVariable);
+  return result;
+}
+
+/**
+ * Converts TypeScript AST nodes to a JSON-safe object
+ * For variable references, it searches for the definition and retrieves its content
+ */
+export function convertToJsonSafeObject(node: ts.Node, sourceFile?: ts.SourceFile): any {
+  // For object literals
+  if (ts.isObjectLiteralExpression(node)) {
+    const result: Record<string, any> = {};
+    node.properties.forEach(prop => {
+      if (ts.isPropertyAssignment(prop)) {
+        const nameNode = prop.name;
+        let propName: string;
+
+        if (ts.isIdentifier(nameNode)) {
+          propName = nameNode.text;
+        } else if (ts.isStringLiteral(nameNode)) {
+          propName = nameNode.text;
+        } else {
+          propName = nameNode.getText();
+        }
+
+        // If the initializer is a variable reference, find its definition
+        if (ts.isIdentifier(prop.initializer) && sourceFile) {
+          const variableName = prop.initializer.text;
+          const variableDefinition = findVariableDefinition(sourceFile, variableName);
+
+          if (variableDefinition) {
+            result[propName] = convertToJsonSafeObject(variableDefinition, sourceFile);
+          } else {
+            result[propName] = `<expr>${variableName}</expr>`;
+          }
+        } else if (ts.isFunctionExpression(prop.initializer) || ts.isArrowFunction(prop.initializer)) {
+          result[propName] = "<expr>AnonymousFunctionAgent</expr>";
+        } else {
+          result[propName] = convertToJsonSafeObject(prop.initializer, sourceFile);
+        }
+      } else if (ts.isShorthandPropertyAssignment(prop)) {
+        const propName = prop.name.text;
+
+        // For shorthand properties, also find their definitions
+        if (sourceFile) {
+          const variableDefinition = findVariableDefinition(sourceFile, propName);
+          if (variableDefinition) {
+            result[propName] = convertToJsonSafeObject(variableDefinition, sourceFile);
+          } else {
+            result[propName] = `<expr>${propName}</expr>`;
+          }
+        } else {
+          result[propName] = `<expr>${propName}</expr>`;
+        }
+      } else if (ts.isSpreadAssignment(prop)) {
+        const spreadExpr = prop.expression;
+
+        // For spread operators, find the referenced object and expand its properties
+        if (ts.isIdentifier(spreadExpr) && sourceFile) {
+          const variableName = spreadExpr.text;
+          const variableDefinition = findVariableDefinition(sourceFile, variableName);
+
+          if (variableDefinition && ts.isObjectLiteralExpression(variableDefinition)) {
+            // Expand the properties of the spread object
+            const spreadObj = convertToJsonSafeObject(variableDefinition, sourceFile);
+            Object.assign(result, spreadObj);
+          } else {
+            result[`...${spreadExpr.getText()}`] = `<expr>${spreadExpr.getText()}</expr>`;
+          }
+        } else {
+          result[`...${spreadExpr.getText()}`] = `<expr>${spreadExpr.getText()}</expr>`;
+        }
+      }
+    });
+    return result;
+  }
+
+  // For array literals
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.map(element => {
+      // If array element is a variable reference
+      if (ts.isIdentifier(element) && sourceFile) {
+        const variableName = element.text;
+        const variableDefinition = findVariableDefinition(sourceFile, variableName);
+
+        if (variableDefinition) {
+          return convertToJsonSafeObject(variableDefinition, sourceFile);
+        }
+      }
+      return convertToJsonSafeObject(element, sourceFile);
+    });
+  }
+
+  // For variable references
+  if (ts.isIdentifier(node) && sourceFile) {
+    const variableName = node.text;
+    const variableDefinition = findVariableDefinition(sourceFile, variableName);
+
+    if (variableDefinition) {
+      return convertToJsonSafeObject(variableDefinition, sourceFile);
+    }
+    return `<expr>${variableName}</expr>`;
+  }
+
+  // For primitive values
+  if (ts.isStringLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return null;
+  }
+  if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
+    return "<expr>undefined</expr>";
+  }
+
+  // For template strings
+  if (ts.isTemplateExpression(node)) {
+    return `<expr>${node.getText()}</expr>`;
+  }
+
+  // For other expressions and variable references, treat as strings
+  return `<expr>${node.getText()}</expr>`;
+}
+
+/**
+ * Parses an object from the entire file with all references resolved
+ */
+export function parseObjectWithReferences(sourceCode: string, position: vscode.Position): any {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceCode,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const objectNode = findObjectAtPosition(sourceCode, position);
+  if (!objectNode) return null;
+
+  return convertToJsonSafeObject(objectNode, sourceFile);
+}


### PR DESCRIPTION
This PR enhances GraphAI Visualizer by improving user experience through the following key changes:

## Key Changes

- **Command Unification**: Merged `showGraph` and `showGraphFromSelection` into a single `showGraph` command
- **TypeScript Support**: Added capability to extract and visualize GraphAI objects from TypeScript files
- **Automatic File Detection**: Implemented intelligent processing that applies appropriate visualization based on file type
- **Documentation Update**: Updated README to reflect the new unified command and TypeScript support

## Feature Overview

Users can now use a single command "GraphAI: Show Graph Visualization" to:
- Visualize entire JSON/YAML files as graphs
- Extract and visualize GraphAI objects from TypeScript files at cursor position

## Technical Implementation

- Added `objectParser.ts` for TypeScript object extraction
- Added `useGraphAIParser.ts` for GraphAI object detection and validation at cursor position
- Implemented automatic file type detection and appropriate processing logic

These changes reduce command redundancy and provide a more intuitive user experience.
