### PR TITLE
Add configurable agent click action

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,18 @@
         "command": "graphai-visualizer.showGraph",
         "title": "GraphAI: Show Graph Visualization"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "GraphAI Visualizer",
+      "properties": {
+        "graphai-visualizer.agentClickAction": {
+          "type": "string",
+          "enum": ["docs", "source"],
+          "default": "docs",
+          "description": "Specifies the action when clicking an agent name. 'docs' opens documentation, 'source' opens source code."
+        }
+      }
+    }
   },
   "scripts": {
     "build": "tsup --env.NODE_ENV production --treeshake",

--- a/src/composables/useAgentProvider.ts
+++ b/src/composables/useAgentProvider.ts
@@ -36,7 +36,10 @@ const SUPPORTED_LANGUAGES: vscode.DocumentFilter[] = [
 /**
  * Creates a regex pattern for finding agent names in different file types
  */
-export const getAgentRegex = (languageId: string, agentNames: string): RegExp => {
+export const getAgentRegex = (
+  languageId: string,
+  agentNames: string,
+): RegExp => {
   const REGEX_PATTERNS: Record<string, string> = {
     json: `"agent"\\s*:\\s*"(${agentNames})"`,
     yaml: `agent:\\s*(?:["'](${agentNames})["']|(${agentNames}))(?:\\s|,|\\]|\\}|$)`,
@@ -50,7 +53,10 @@ export const getAgentRegex = (languageId: string, agentNames: string): RegExp =>
 /**
  * Retrieves agent information from the agent index
  */
-export const getAgentInfo = (agentName: string, agentIndex: AgentIndex): AgentInfo | undefined => {
+export const getAgentInfo = (
+  agentName: string,
+  agentIndex: AgentIndex,
+): AgentInfo | undefined => {
   return agentIndex.agents.find((agent) => agent.name === agentName);
 };
 
@@ -97,7 +103,9 @@ const createHoverProvider = (agentIndex: AgentIndex): vscode.HoverProvider => {
  * Creates a link provider for agent navigation
  * Uses configuration to determine click behavior (docs or source)
  */
-const createLinkProvider = (agentIndex: AgentIndex): vscode.DocumentLinkProvider => {
+const createLinkProvider = (
+  agentIndex: AgentIndex,
+): vscode.DocumentLinkProvider => {
   const agentNames = agentIndex.agents.map((agent) => agent.name).join("|");
   return {
     provideDocumentLinks(document: vscode.TextDocument) {
@@ -126,7 +134,11 @@ const createLinkProvider = (agentIndex: AgentIndex): vscode.DocumentLinkProvider
 
           const link = new vscode.DocumentLink(
             range,
-            vscode.Uri.parse(config.agentClickAction.value === "docs" ? agentInfo.docs : agentInfo.source),
+            vscode.Uri.parse(
+              config.agentClickAction.value === "docs"
+                ? agentInfo.docs
+                : agentInfo.source,
+            ),
           );
           link.tooltip = `Click to open ${config.agentClickAction.value === "docs" ? "documentation" : "source code"} for ${agentName}`;
           links.push(link);

--- a/src/composables/useAgentProvider.ts
+++ b/src/composables/useAgentProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import agentIndex from "../agentIndex.json";
 
 // Types
 interface AgentInfo {
@@ -14,6 +13,10 @@ interface AgentProvider {
   dispose: () => void;
 }
 
+export interface AgentIndex {
+  agents: AgentInfo[];
+}
+
 // Constants
 const SUPPORTED_LANGUAGES: vscode.DocumentFilter[] = [
   { scheme: "file", language: "yaml" },
@@ -21,105 +24,108 @@ const SUPPORTED_LANGUAGES: vscode.DocumentFilter[] = [
   { scheme: "file", language: "typescript" },
 ];
 
-const AGENT_NAMES = agentIndex.agents.map((agent) => agent.name).join("|");
-
-const REGEX_PATTERNS: Record<string, string> = {
-  json: `"agent"\\s*:\\s*"(${AGENT_NAMES})"`,
-  yaml: `agent:\\s*(?:["'](${AGENT_NAMES})["']|(${AGENT_NAMES}))(?:\\s|,|\\]|\\}|$)`,
-  typescript: `agent:\\s*["'](${AGENT_NAMES})["']`,
-  default: `agent:\\s*["'](${AGENT_NAMES})["']`,
-};
-
 // Helper functions
-export const getAgentRegex = (languageId: string): RegExp => {
+export const getAgentRegex = (languageId: string, agentNames: string): RegExp => {
+  const REGEX_PATTERNS: Record<string, string> = {
+    json: `"agent"\\s*:\\s*"(${agentNames})"`,
+    yaml: `agent:\\s*(?:["'](${agentNames})["']|(${agentNames}))(?:\\s|,|\\]|\\}|$)`,
+    typescript: `agent:\\s*["'](${agentNames})["']`,
+    default: `agent:\\s*["'](${agentNames})["']`,
+  };
   const pattern = REGEX_PATTERNS[languageId] || REGEX_PATTERNS.default;
   return new RegExp(pattern, "g");
 };
 
-export const getAgentInfo = (agentName: string): AgentInfo | undefined => {
+export const getAgentInfo = (agentName: string, agentIndex: AgentIndex): AgentInfo | undefined => {
   return agentIndex.agents.find((agent) => agent.name === agentName);
 };
 
 // Provider implementations
-const createHoverProvider = (): vscode.HoverProvider => ({
-  provideHover(document: vscode.TextDocument, position: vscode.Position) {
-    const line = document.lineAt(position.line).text;
-    const agentRegex = getAgentRegex(document.languageId);
-    const wordRange = document.getWordRangeAtPosition(position, agentRegex);
+const createHoverProvider = (agentIndex: AgentIndex): vscode.HoverProvider => {
+  const agentNames = agentIndex.agents.map((agent) => agent.name).join("|");
+  return {
+    provideHover(document: vscode.TextDocument, position: vscode.Position) {
+      const line = document.lineAt(position.line).text;
+      const agentRegex = getAgentRegex(document.languageId, agentNames);
+      const wordRange = document.getWordRangeAtPosition(position, agentRegex);
 
-    if (!wordRange) return null;
+      if (!wordRange) return null;
 
-    const match = agentRegex.exec(
-      line.substring(wordRange.start.character, wordRange.end.character),
-    );
-    if (!match) return null;
+      const match = agentRegex.exec(
+        line.substring(wordRange.start.character, wordRange.end.character),
+      );
+      if (!match) return null;
 
-    const agentName = match[1] || match[2];
-    const agentInfo = getAgentInfo(agentName);
-    if (!agentInfo) return null;
+      const agentName = match[1] || match[2];
+      const agentInfo = getAgentInfo(agentName, agentIndex);
+      if (!agentInfo) return null;
 
-    const md = new vscode.MarkdownString();
-    md.isTrusted = true;
-    md.supportHtml = true;
-    md.appendMarkdown(`**${agentName}**\n\n`);
-    md.appendMarkdown(
-      `[Docs](${agentInfo.docs}) | [Source](${agentInfo.source})\n\n`,
-    );
+      const md = new vscode.MarkdownString();
+      md.isTrusted = true;
+      md.supportHtml = true;
+      md.appendMarkdown(`**${agentName}**\n\n`);
+      md.appendMarkdown(
+        `[Docs](${agentInfo.docs}) | [Source](${agentInfo.source})\n\n`,
+      );
 
-    return new vscode.Hover(md, wordRange);
-  },
-});
+      return new vscode.Hover(md, wordRange);
+    },
+  };
+};
 
-const createLinkProvider = (): vscode.DocumentLinkProvider => ({
-  provideDocumentLinks(document: vscode.TextDocument) {
-    const links: vscode.DocumentLink[] = [];
-    const agentRegex = getAgentRegex(document.languageId);
+const createLinkProvider = (agentIndex: AgentIndex): vscode.DocumentLinkProvider => {
+  const agentNames = agentIndex.agents.map((agent) => agent.name).join("|");
+  return {
+    provideDocumentLinks(document: vscode.TextDocument) {
+      const links: vscode.DocumentLink[] = [];
+      const agentRegex = getAgentRegex(document.languageId, agentNames);
 
-    for (let i = 0; i < document.lineCount; i++) {
-      const line = document.lineAt(i).text;
-      agentRegex.lastIndex = 0;
+      for (let i = 0; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text;
+        agentRegex.lastIndex = 0;
 
-      let match: RegExpExecArray | null = agentRegex.exec(line);
-      while (match !== null) {
-        const agentName = match[1] || match[2];
-        const agentInfo = getAgentInfo(agentName);
-        if (!agentInfo) {
+        let match: RegExpExecArray | null = agentRegex.exec(line);
+        while (match !== null) {
+          const agentName = match[1] || match[2];
+          const agentInfo = getAgentInfo(agentName, agentIndex);
+          if (!agentInfo) {
+            match = agentRegex.exec(line);
+            continue;
+          }
+
+          const startPos = match.index + match[0].indexOf(agentName);
+          const endPos = startPos + agentName.length;
+          const range = new vscode.Range(
+            new vscode.Position(i, startPos),
+            new vscode.Position(i, endPos),
+          );
+
+          const link = new vscode.DocumentLink(
+            range,
+            vscode.Uri.parse(agentInfo.docs),
+          );
+          link.tooltip = `Click to open documentation for ${agentName}`;
+          links.push(link);
+
           match = agentRegex.exec(line);
-          continue;
         }
-
-        const startPos = match.index + match[0].indexOf(agentName);
-        const endPos = startPos + agentName.length;
-        const range = new vscode.Range(
-          new vscode.Position(i, startPos),
-          new vscode.Position(i, endPos),
-        );
-
-        const link = new vscode.DocumentLink(
-          range,
-          vscode.Uri.parse(agentInfo.docs),
-        );
-        link.tooltip = `Click to open documentation for ${agentName}`;
-        links.push(link);
-
-        match = agentRegex.exec(line);
       }
-    }
 
-    return links;
-  },
-});
+      return links;
+    },
+  };
+};
 
 // Main provider
-export const useAgentProvider = (): AgentProvider => {
+export const useAgentProvider = (agentIndex: AgentIndex): AgentProvider => {
   const hoverProvider = vscode.languages.registerHoverProvider(
     SUPPORTED_LANGUAGES,
-    createHoverProvider(),
+    createHoverProvider(agentIndex),
   );
 
   const linkProvider = vscode.languages.registerDocumentLinkProvider(
     SUPPORTED_LANGUAGES,
-    createLinkProvider(),
+    createLinkProvider(agentIndex),
   );
 
   return {

--- a/src/composables/useGraphAIParser.ts
+++ b/src/composables/useGraphAIParser.ts
@@ -1,6 +1,5 @@
 import type * as vscode from "vscode";
 import { parseObjectWithReferences } from "../lib/objectParser";
-import { logger } from "../utils";
 
 /**
  * Parses GraphAI object from cursor position

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,12 +9,16 @@ import { window, workspace } from "vscode";
 import { useAgentProvider } from "./composables/useAgentProvider";
 import { parseGraphAIObject } from "./composables/useGraphAIParser";
 import { useMermaidWebview } from "./composables/useMermaidWebview";
+import { fetchAgentIndex } from "./lib/fetchAgentIndex";
 import { logger } from "./utils";
 
 // @ts-ignore
-export = defineExtension(() => {
+export = defineExtension(async () => {
   logger.info("Extension Activated");
   const onDidSaveTextDocument = useEvent(workspace.onDidSaveTextDocument);
+
+  // 起動時にagentIndexを取得
+  const agentIndex = await fetchAgentIndex();
 
   /**
    * Show graph from JSON, YAML file or TypeScript selection
@@ -91,7 +95,7 @@ export = defineExtension(() => {
     );
   });
 
-  const { hoverProvider, linkProvider, dispose } = useAgentProvider();
+  const { hoverProvider, linkProvider, dispose } = useAgentProvider(agentIndex);
 
   return {
     hoverProvider,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,10 @@
+import { defineConfigs } from 'reactive-vscode';
+import type { AgentClickAction } from '../types/config';
+
+/**
+ * Configuration for GraphAI Visualizer
+ * Defines settings for agent click behavior
+ */
+export const config = defineConfigs('graphai-visualizer', {
+  agentClickAction: String as unknown as AgentClickAction,
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,10 +1,10 @@
-import { defineConfigs } from 'reactive-vscode';
-import type { AgentClickAction } from '../types/config';
+import { defineConfigs } from "reactive-vscode";
+import type { AgentClickAction } from "../types/config";
 
 /**
  * Configuration for GraphAI Visualizer
  * Defines settings for agent click behavior
  */
-export const config = defineConfigs('graphai-visualizer', {
+export const config = defineConfigs("graphai-visualizer", {
   agentClickAction: String as unknown as AgentClickAction,
 });

--- a/src/lib/fetchAgentIndex.ts
+++ b/src/lib/fetchAgentIndex.ts
@@ -7,12 +7,12 @@ import { logger } from "../utils";
 export const fetchAgentIndex = async (): Promise<AgentIndex> => {
   try {
     const response = await fetch(
-      "https://raw.githubusercontent.com/kawamataryo/graphai-visualizer/main/src/agentIndex.json"
+      "https://raw.githubusercontent.com/kawamataryo/graphai-visualizer/main/src/agentIndex.json",
     );
     if (!response.ok) {
       throw new Error("Failed to fetch agentIndex.json");
     }
-    return await response.json() as AgentIndex;
+    return (await response.json()) as AgentIndex;
   } catch (error) {
     logger.error("Error fetching agentIndex:", error);
     // Fallback to local agentIndex

--- a/src/lib/fetchAgentIndex.ts
+++ b/src/lib/fetchAgentIndex.ts
@@ -1,0 +1,22 @@
+import type { AgentIndex } from "../composables/useAgentProvider";
+import { logger } from "../utils";
+
+/**
+ * Fetch agentIndex from GitHub
+ */
+export const fetchAgentIndex = async (): Promise<AgentIndex> => {
+  try {
+    const response = await fetch(
+      "https://raw.githubusercontent.com/kawamataryo/graphai-visualizer/main/src/agentIndex.json"
+    );
+    if (!response.ok) {
+      throw new Error("Failed to fetch agentIndex.json");
+    }
+    return await response.json() as AgentIndex;
+  } catch (error) {
+    logger.error("Error fetching agentIndex:", error);
+    // Fallback to local agentIndex
+    const localAgentIndex = await import("../agentIndex.json");
+    return localAgentIndex as AgentIndex;
+  }
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,11 +1,11 @@
-import type { ConfigRef } from 'reactive-vscode';
+import type { ConfigRef } from "reactive-vscode";
 
 /**
  * Type for agent click action configuration
  * 'docs' - Opens documentation
  * 'source' - Opens source code
  */
-export type AgentClickAction = 'docs' | 'source';
+export type AgentClickAction = "docs" | "source";
 
 /**
  * Configuration interface for GraphAI Visualizer

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,18 @@
+import type { ConfigRef } from 'reactive-vscode';
+
+/**
+ * Type for agent click action configuration
+ * 'docs' - Opens documentation
+ * 'source' - Opens source code
+ */
+export type AgentClickAction = 'docs' | 'source';
+
+/**
+ * Configuration interface for GraphAI Visualizer
+ */
+export interface GraphAIVisualizerConfig {
+  /**
+   * Configuration for agent click action
+   */
+  agentClickAction: ConfigRef<AgentClickAction>;
+}


### PR DESCRIPTION
## Changes

- Add configuration option for agent click action (docs/source)
- Add remote agent index fetching with local fallback
- Add English documentation and comments
- Fix code style and formatting
- Add .cursor to gitignore

## Details

### Configuration Option
This PR adds a new configuration option that allows users to customize the behavior when clicking on an agent name. Users can choose between:

- 'docs' (default) - Opens the documentation page
- 'source' - Opens the source code page

The configuration can be changed through VSCode settings under 'GraphAI Visualizer' section.

### Remote Agent Index
The extension now fetches the agent index from the GitHub repository instead of using a local file:
- Primary source: https://raw.githubusercontent.com/kawamataryo/graphai-visualizer/main/src/agentIndex.json
- Falls back to local agentIndex.json if remote fetch fails
- Improves maintainability by centralizing agent definitions

## Testing

- [x] Verify that clicking on agent names opens documentation by default
- [x] Verify that changing the setting to 'source' makes clicks open source code instead
- [x] Verify that hover tooltips correctly reflect the current setting
- [x] Verify that the setting changes take effect without requiring a restart
- [x] Verify that agent index is fetched from remote source on extension activation
- [x] Verify that local fallback works when offline or remote fetch fails